### PR TITLE
clean company names

### DIFF
--- a/src/cleaning_functions.py
+++ b/src/cleaning_functions.py
@@ -1,5 +1,5 @@
-import re
 import pandas as pd
+import re
 
 
 def pandas_vector_to_list(pandas_df):
@@ -73,7 +73,8 @@ def update_location(location_raw, cleaned_location):
     return list_cleaned_location
 
 
-def remove_sub_string(sub_string, feature, remove_preceding_white_space=True):
+def remove_sub_string(sub_string, feature, remove_preceding_white_space=True,
+                      replacement_string=''):
     """
     Auxiliary function for removing a substring from a feature
     E.g. In category: Sales Jobs -> Sales
@@ -81,6 +82,7 @@ def remove_sub_string(sub_string, feature, remove_preceding_white_space=True):
     :param sub_string: the substring you would like to remove
     :param feature: the feature to remove the substring from
     :param remove_preceding_white_space: Defaults to True
+    :param replacement_string: string to use for substitution - defaults to ''
     :return: feature list with the substring removed
     """
     # Guard against non-lists
@@ -89,13 +91,16 @@ def remove_sub_string(sub_string, feature, remove_preceding_white_space=True):
     else:
         feature_as_list = pandas_vector_to_list(feature)
 
-    white_space_matcher = '\s'
+    # optional whitespace (?)
+    white_space_matcher = '\s?'
     if not remove_preceding_white_space:
         white_space_matcher = ''
 
-    feature_with_removed_sub_string = [
-        re.sub(white_space_matcher + sub_string, '', row, flags=re.I) for row
-        in feature_as_list
-    ]
+    # compile re outside of list comprehension
+    regex = re.compile(white_space_matcher + sub_string, flags=re.I)
+
+    feature_with_removed_sub_string = [regex.sub(replacement_string, row) if isinstance(row, str)
+                                       else ''  # return default string for NANs
+                                       for row in feature_as_list]
 
     return feature_with_removed_sub_string

--- a/src/company_feature_extraction.py
+++ b/src/company_feature_extraction.py
@@ -1,0 +1,94 @@
+from collections import Counter
+
+from cleaning_functions import remove_sub_string, pandas_vector_to_list
+from job_description_feature_extraction import get_top_idf_features
+
+
+def clean_company_name(company_names):
+    # 1. remove high scoring idf terms ('stop words' for this specific case)
+    feature_as_list = remove_common_terms(company_names)
+
+    # 2. remove/replace special characters
+    feature_as_list = remove_special_chars(feature_as_list)
+
+    # 3. strip and lowercase only after we have removed all special chars
+    feature_as_list = [x.lower().strip() for x in feature_as_list]
+
+    # debug_output(company_names, feature_as_list)
+
+    return feature_as_list
+
+
+def debug_output(company_names, feature_as_list):
+    counter_clean = Counter(feature_as_list)
+    counter_dirty = Counter([x.strip() if isinstance(x, str)
+                             else ''  # return default string for NANs
+                             for x in pandas_vector_to_list(company_names)])
+    print("unique count dirty = {} of which {} are ''".format(
+        len(counter_dirty), counter_dirty['']))
+    print("unique count clean = {} of which {} are ''".format(
+        len(counter_clean), counter_clean['']))
+    # save unique company names to txt file
+    open('companies.txt', 'w').write(
+        '\n'.join(sorted([x + "||" + str(y) for x, y in counter_clean.items() if y > 0])))
+
+
+def remove_special_chars(company_names):
+    """
+    replaces special characters from company names
+
+    :param company_names: list of strings
+    :return: list of company names with special chars removed/replaced
+    """
+    regex_remove_special_chars = '([\.&,/\'])'
+    regex_replace_special_chars = '[-–]'
+    regex_replace_multiple_spaces = '[\s]{2,}'
+    feature_as_list = remove_sub_string(regex_remove_special_chars, company_names, False)
+    feature_as_list = remove_sub_string(regex_replace_special_chars, feature_as_list, False, " ")
+    feature_as_list = remove_sub_string(regex_replace_multiple_spaces, feature_as_list, False, " ")
+    return feature_as_list
+
+
+def remove_common_terms(company_names):
+    """
+    removes an automatic compiled list of common terms like 'ltd', 'group' and so on
+     to group and reduce the number of unique company names
+
+    :param company_names: list of strings
+    :return: list of company names with 'stop words' removed
+    """
+    # this is a mostly automatic compiled list of terms
+    # using company_feature_extraction._find_top_idf_words
+    # manually removed obvious company names which we do not want to include
+    common_terms = ['ltd', 'recruitment', 'limited', 'group', 'services', 'the', 'solutions',
+                    'school', 'uk', 'and', 'care', 'of', 'associates', 'consulting', 'resourcing',
+                    'personnel', 'search', 'primary', 'council', 'college', 'people', 'it',
+                    'selection', 'cleaning', 'london', 'university', 'management', 'international',
+                    'home', 'trust', 'plc', 'education', 'resources', 'centre', 'st', 'healthcare',
+                    'technical', 'consultancy', 'support', 'hotel', 'street', 'academy',
+                    'consultants', 'house', 'company', 'for', 'housing', 'employment',
+                    'resource', 'engineering', 'recruit', 'bureau', 'partnership', 'co', 'security',
+                    'training', 'health', 'technology', 'global', 'brook', 'business', 'executive',
+                    'legal', 'appointments', 'media', 'first', 'service', 'marketing',
+                    'association', 'community', 'agency', 'park', 'network', 'financial', 'hr',
+                    'sales', 'direct', 'foundation', 'retail', 'professional', 'partners', 'jobs',
+                    'nursing', 'society', 'construction', 'staff', 'llp', '.co.uk']
+    # watch out for word boundaries \b
+    regex_remove_common_terms = r"\b(" + '|'.join(common_terms) + r")\b"
+    return remove_sub_string(regex_remove_common_terms, company_names)
+
+
+def _find_top_idf_words(company_names):
+    """
+    determines highest scoring idf terms ('stop words' for this specific case)
+    used to be remove terms from our company names to reduce the unique count of company names
+
+    :param company_names: list of strings
+    :return: list of highest scoring idf terms
+    """
+    feature_as_list = remove_special_chars(company_names)
+    feature_as_list = [x.lower().strip() for x in feature_as_list]
+    feature_as_list = set(feature_as_list)
+    features = get_top_idf_features(feature_as_list, 100, 1)
+    print(features)
+    return features

--- a/src/job_description_feature_extraction.py
+++ b/src/job_description_feature_extraction.py
@@ -129,12 +129,14 @@ def get_rake_keywords(job_description):
     return keywords
 
 
-def get_top_idf_features(job_description, k):
+def get_top_idf_features(job_description, k, order=-1):
     """
     use TfIdf to extract top k keywords of corpus
 
     :param job_description: data frame
-    :param k: number of
+    :param k: number of top features
+    :param order: sort order of idf features (least or most significant features)
+        defaults to -1 = most significant features
     :return: list of k top features
     """
     # based on https://stackoverflow.com/questions/25217510/
@@ -142,7 +144,7 @@ def get_top_idf_features(job_description, k):
     # use _build_idf_dict to get a {term: score} dictionary which was the whole point here
     # but it makes the build fail because of unused variables so yea
     # idf_dict = _build_idf_dict(tfidf_vectorizer)
-    idf_ranking = np.argsort(tfidf_vectorizer.idf_)[::-1]
+    idf_ranking = np.argsort(tfidf_vectorizer.idf_)[::order]
     features = tfidf_vectorizer.get_feature_names()
     return [features[i] for i in idf_ranking[:k]]
 


### PR DESCRIPTION
cleaning company names by
1) removing special chars / lower casing / stripping and so on
2) removing high scoring idf terms using deterministic method such as 'ltd', 'group', 'international'

this reduces the number of unique companies from 18k to ~12k

an open issue in this topic is that some companies names should be merged
e.g.
- 24 7
- 24 seven
- 247

but doing that automatically while preserving companies that should NOT be merged is kind of hard and does more harm than good
e.g.
- red
- red rockhip
- red sky
- red snapper
- red teachers