### PR TITLE
Feature dropping functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ python-rake>=1.0.7
 sklearn
 scipy==0.18.0
 keras==1.2.1
-tensorflow==0.12.1
+tensorflow==1.1.0
 matplotlib==2.0.0
 tqdm==4.11.2
-

--- a/src/models/BaseModel.py
+++ b/src/models/BaseModel.py
@@ -1,4 +1,3 @@
-import abc
 import numpy as np
 import os.path
 import pandas as pd
@@ -281,10 +280,14 @@ class BaseModel(object):
         :param train_result: list of predictions for train set
         :param train_result: list of predictions for test set
         """
-        train_error = sklearn.metrics.mean_absolute_error(self.y_train, train_result)
-        test_error = sklearn.metrics.mean_absolute_error(self.y_test, test_result)
-        print("Train MSE of {}: {}".format(self.__class__.__name__, train_error))
-        print("Test MSE of {}: {}".format(self.__class__.__name__, test_error))
+        train_error = sklearn.metrics.mean_absolute_error(self.y_train,
+                                                          train_result)
+        test_error = sklearn.metrics.mean_absolute_error(self.y_test,
+                                                         test_result)
+        print("Train MAE of {}: {}".format(self.__class__.__name__,
+                                           train_error))
+        print("Test MAE of {}: {}".format(self.__class__.__name__,
+                                          test_error))
         return (train_error, test_error)
 
     # from https://stackoverflow.com/questions/8955448

--- a/src/models/BaseModel.py
+++ b/src/models/BaseModel.py
@@ -94,7 +94,7 @@ class BaseModel(object):
                 train_size=train_size,
                 test_size=test_size,
                 random_state=1)
-        except:
+        except AttributeError:
             print("Not loading description training/test data because "
                   "description data was not loaded.")
         self.x_train = self.train_data[:, 0:self.train_data.shape[1] - 1]
@@ -107,11 +107,20 @@ class BaseModel(object):
         self.mae_test_error = -1
 
     def _get_feature_indices(self, feature_name):
+        """
+        Figure out the indices of a feature based on the data in the
+        feature_names attribute (i.e: from Feature_List.csv) and spit them
+        out.
+        :param feature_name: the feature for which you'd like the indices
+        :return: the indices of that feature as a range in an array
+        """
         range_start = 0
         range_end = 0
         for row in self.feature_list:
+            # each *row* looks like ['feature_name', 5]
             if row[0] == feature_name:
                 range_end = range_start + row[1]
+                # aight, we found what we wanted, break out.
                 break
             else:
                 range_start += row[1]

--- a/src/models/BaseModel.py
+++ b/src/models/BaseModel.py
@@ -40,6 +40,8 @@ class BaseModel(object):
         """
         print('Initialized {}'.format(self.__class__.__name__))
 
+        self.drop_feature_names = drop_feature_names
+
         if os.path.exists(BaseModel.CLEANED_FILE_NAME):
             print('Pre-processed data exists, reading from the file')
             self.cleaned_encoded_data, self.feature_list = self.load_cleaned_data()

--- a/src/models/RandomForestRegressor.py
+++ b/src/models/RandomForestRegressor.py
@@ -5,7 +5,7 @@ from models.BaseModel import BaseModel
 class RandomForestRegressor(BaseModel):
     def predict(self):
         regr_rf = RFR(max_depth=None, random_state=9, n_estimators=100, min_samples_split=10,
-                      min_samples_leaf=10)
+                      min_samples_leaf=10, n_jobs=-1)
         regr_rf.fit(self.x_train, self.y_train)
         train_result = regr_rf.predict(self.x_train)
         test_result = regr_rf.predict(self.x_test)

--- a/src/models/RandomForestRegressor.py
+++ b/src/models/RandomForestRegressor.py
@@ -9,5 +9,10 @@ class RandomForestRegressor(BaseModel):
         regr_rf.fit(self.x_train, self.y_train)
         train_result = regr_rf.predict(self.x_train)
         test_result = regr_rf.predict(self.x_test)
-        BaseModel.export_prediction(test_result, 'RandomForestReg')
+
+        export_filename = 'RandomForestReg'
+        if self.drop_feature_names:
+            export_filename += '_without_' + '_'.join(self.drop_feature_names)
+
+        BaseModel.export_prediction(test_result, export_filename)
         return (train_result, test_result)

--- a/src/models/RandomForestRegressor.py
+++ b/src/models/RandomForestRegressor.py
@@ -4,8 +4,10 @@ from models.BaseModel import BaseModel
 
 class RandomForestRegressor(BaseModel):
     def predict(self):
-        regr_rf = RFR(max_depth=None, random_state=9, n_estimators=100, min_samples_split=10,
-                      min_samples_leaf=10, n_jobs=-1)
+        regr_rf = RFR(max_depth=17,
+                      random_state=9,
+                      n_estimators=50,
+                      n_jobs=-1)
         regr_rf.fit(self.x_train, self.y_train)
         train_result = regr_rf.predict(self.x_train)
         test_result = regr_rf.predict(self.x_test)


### PR DESCRIPTION
 - So find how to drop certain feature columns from the cleaned data before doing any processing, it's a little crude, using the csv with the feature lengths, but oh well it seems to work.
-  takes the opportunity to pop in n_jobs on the RandomForestRegressor.
- bumps tensorflow version, the old one seems to have evaporated from pypi

I've built my own 'main' for this which i'm not including here, it will run RandomForestRegressor while dropping the columns: `['contract_type', 'contract_time', 'company', 'source', 'town', 'region', 'job_titles', 'categories']` in all their combinations, ~255 - currently running.

Appreciate if someone can point out bugs, i'm sure they exist.